### PR TITLE
Capture the exception to properly log warning messages when a keyspac…

### DIFF
--- a/lib/cmdb/consul_source.rb
+++ b/lib/cmdb/consul_source.rb
@@ -58,7 +58,7 @@ module CMDB
         value = process_value(item[:value])
         yield(key, value)
       end
-    rescue Diplomat::KeyNotFound
+    rescue Diplomat::KeyNotFound => exc
       CMDB.log.warn exc.message
     end
 


### PR DESCRIPTION
…e is not found

Fixes issue https://github.com/rightscale/cmdb/issues/3
